### PR TITLE
Remove pegged imglib2 version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>4.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>


### PR DESCRIPTION
Fixes issue: https://github.com/imglib/imglib2-tutorials/issues/2